### PR TITLE
Improved icon search filtering; one more hero triplet

### DIFF
--- a/src/js/App.js
+++ b/src/js/App.js
@@ -113,7 +113,7 @@ class App extends Component {
         <Box justify='center' direction='row' pad={{ horizontal: 'medium', vertical: 'small' }}>
           <Search
             value={search}
-            placeholder={`Search ${iconKeys.length} icons (e.g. social, delete, user)`}
+            placeholder={`Search ${iconKeys.length} icons (e.g. social, delete, user, arrow, sport, player)`}
             onInput={event => this.setState({ search: event.target.value, currentPage: 1 })}
           />
         </Box>

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -52,7 +52,9 @@ class App extends Component {
     let iconsNode = iconKeys
       .filter(icon => (
         icon.toLowerCase().match(search.toLowerCase()) ||
-        (metadata[icon] || []).some(synonym => synonym.toLowerCase().match(search.toLowerCase()))
+        (metadata[icon] || []).some(
+          synonym => synonym.substr(0, search.length).toLowerCase() === search.toLowerCase()
+        )
       ));
 
     iconsNode = iconsNode.map((icon, index) => {

--- a/src/js/components/IconHero.js
+++ b/src/js/components/IconHero.js
@@ -51,6 +51,7 @@ import {
   Refresh,
   Restaurant,
   Run,
+  SafariOption,
   Search,
   Send,
   Star,
@@ -207,7 +208,7 @@ const messages = [
   {
     text: 'Cross-browser, of course',
     icons: [
-      InternetExplorer, Chrome, Opera,
+      InternetExplorer, SafariOption, Opera,
     ],
   },
   {


### PR DESCRIPTION
Search now matches tags using 'starts with' rather than 'contains'.

For example, searching for  "sport" will bring up the proper sports-related icons and NOT include icons tagged "transportation".